### PR TITLE
feat: Enable FatLTO and CU1 for the Dist profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,10 @@ inquire = "0.7.5"
 cargo_toml = "0.22"
 cargo_metadata = "0.20"
 
+[profile.release]
+codegen-units = 1
+lto = true
+
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-codegen-units = 1
-lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,5 @@ cargo_metadata = "0.20"
 # The profile that 'dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+codegen-units = 1
+lto = true


### PR DESCRIPTION
Resolves https://github.com/HaoboGu/rmkit/issues/9

Just wanted to ask a question - do we want to apply the same settings for the Release profile too? On one hand, we will deliver smaller by default binaries for `cargo install` users too (not only prebuilt binaries), on the other hand - the installation process (the building process on their local machine) will take more time.

What do you think?